### PR TITLE
add "Metal 0.4mm" to "compatible" (PC/ABS)

### DIFF
--- a/ks_includes/materials.json
+++ b/ks_includes/materials.json
@@ -140,7 +140,8 @@
         "name": "PC/ABS",
         "code": "PC-ABS",
         "compatible": [
-            "Standard 0.4mm"
+            "Standard 0.4mm",
+            "Metal 0.4mm"
         ],
         "experimental": [
             "Standard 0.8mm"


### PR DESCRIPTION
add "Metal 0.4mm" to "compatible" (PC/ABS)